### PR TITLE
fix: admin notifications

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -102,7 +102,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: host.docker.internal
     steps:
-      - uses: OpenSourcePolitics/build-and-test-images-action@master
+      - uses: OpenSourcePolitics/build-and-test-images-action@ppan
         with:
           registry: ${{ vars.REGISTRY_ENDPOINT }}
           namespace: ${{ vars.REGISTRY_NAMESPACE }}

--- a/app/mailers/decidim/destroy_account_mailer.rb
+++ b/app/mailers/decidim/destroy_account_mailer.rb
@@ -14,7 +14,7 @@ module Decidim
         @initiatives = Decidim::Initiative.where(author: @user).where.not(state: [:created, :discarded, :classified])
 
         subject = I18n.t("notify.subject", scope: "decidim.destroy_account_mailer")
-        mail(to: user.email, subject: subject)
+        mail(to: @admin.email, subject: subject)
       end
     end
 

--- a/spec/commands/decidim/destroy_account_spec.rb
+++ b/spec/commands/decidim/destroy_account_spec.rb
@@ -62,6 +62,20 @@ module Decidim
           .with(admin, user)
       end
 
+      context "when admin has no email_on_notification" do
+        let!(:admin) { create(:user, :confirmed, :admin, organization: user.organization, email_on_notification: false) }
+
+        it "does not notify admin" do
+          allow(DestroyAccountMailer).to receive(:notify).with(admin, user).and_call_original
+
+          command.call
+
+          expect(DestroyAccountMailer)
+            .not_to have_received(:notify)
+            .with(admin, user)
+        end
+      end
+
       it "destroys the current user avatar" do
         command.call
         expect(user.reload.avatar).not_to be_present

--- a/spec/mailers/destroy_account_mailer_spec.rb
+++ b/spec/mailers/destroy_account_mailer_spec.rb
@@ -6,6 +6,7 @@ module Decidim
   describe DestroyAccountMailer, type: :mailer do
     let(:organization) { create(:organization) }
     let(:admin) { create(:user, :admin, organization: organization) }
+    let(:user) { create(:user, :confirmed, organization: organization) }
     let!(:initiative) { create(:initiative, organization: organization, state: :published) }
 
     let(:default_subject) { "A user has deleted his account." }
@@ -15,6 +16,8 @@ module Decidim
       let(:mail) { described_class.notify(admin, initiative.author) }
 
       it "notify admins" do
+        expect(mail.to).not_to include(user.email)
+        expect(mail.to).to include(admin.email)
         expect(mail.subject).to eq(default_subject)
         expect(mail.body.encoded).to match(default_body)
         expect(mail.body.encoded).to match(initiative.id.to_s)
@@ -25,7 +28,6 @@ module Decidim
 
       context "when user has no initiative" do
         let!(:initiative) { nil }
-        let(:user) { create(:user, :confirmed, organization: organization) }
         let(:mail) { described_class.notify(admin, user) }
 
         it "notify admins" do


### PR DESCRIPTION
#### Description

When user destroy her account, admin should be notified only if `email_on_notification` is truthy